### PR TITLE
fix: compiling webview shared library on linux

### DIFF
--- a/script/build.ts
+++ b/script/build.ts
@@ -115,25 +115,14 @@ switch (Deno.build.os) {
         exit: ExitType.Fail,
         args: [
           "webview/webview.cc",
-          "-c",
           "-DWEBVIEW_GTK",
+          "-shared",
           "-std=c++11",
           "-Wall",
           "-Wextra",
           "-pedantic",
           "-fpic",
-          ...stdout.split(" "),
-          "-o",
-          "build/webview.o",
-        ],
-      },
-    });
-    await spawn("c++", {
-      opts: {
-        exit: ExitType.Fail,
-        args: [
-          "build/webview.o",
-          "-shared",
+          ...stdout.trim().split(" "),
           "-o",
           "build/libwebview.so",
         ],


### PR DESCRIPTION
fix https://github.com/webview/webview_deno/issues/114

stdout had an extra '\n' that was messing the c++ invocation

Also compiling on two steps doesn't seem to work so I just merged it into one.