### PR TITLE
Adds support for Apple silicon

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,15 +75,33 @@ jobs:
           command: build
           args: --release --target=${{ matrix.build.target }}
 
+      - name: Package macOS
+        if:  matrix.build.id == 'macos'
+        run: mv target/${{ matrix.build.target }}/release/libwebview_deno.dylib libwebview_deno.x86_64.dylib
+
+      - name: Package macOS-arm
+        if:  matrix.build.id == 'macos-arm64'
+        run: mv target/${{ matrix.build.target }}/release/libwebview_deno.dylib libwebview_deno.aarch64.dylib
+
+      - name: Package Windows
+        if:  matrix.build.id == 'windows'
+        run: |
+          mv target/${{ matrix.build.target }}/release/webview_deno.dll webview_deno.x86_64.dll
+          mv target/${{ matrix.build.target }}/release/Webview2Loader.dll Webview2Loader.dll
+
+      - name: Package Linux
+        if:  matrix.build.id == 'linux'
+        run: mv target/${{ matrix.build.target }}/release/webview_deno.so webview_deno.x86_64.so
+
       - uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.build.id }}
           path: |
-            target/${{ matrix.build.target }}/release/libwebview_deno.dylib
-            target/${{ matrix.build.target }}/release/libwebview_deno.dylib
-            target/${{ matrix.build.target }}/release/libwebview_deno.so
-            target/${{ matrix.build.target }}/release/webview_deno.dll
-            target/${{ matrix.build.target }}/release/Webview2Loader.dll
+            libwebview_deno.x86_64.dylib
+            libwebview_deno.aarch64.dylib
+            libwebview_deno.x86_64.so
+            webview_deno.x86_64.dll
+            Webview2Loader.dll
 
       - name: Release Plugin
         uses: softprops/action-gh-release@master
@@ -94,7 +112,8 @@ jobs:
           tag_name: "webview_deno release"
           draft: true
           files: |
-            target/release/libwebview_deno.dylib
-            target/release/libwebview_deno.so
-            target/release/webview_deno.dll
-            target/release/Webview2Loader.dll
+            libwebview_deno.x86_64.dylib
+            libwebview_deno.aarch64.dylib
+            libwebview_deno.x86_64.so
+            webview_deno.x86_64.dll
+            Webview2Loader.dll

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,15 +15,19 @@ jobs:
         - id: macos
           os: macOS-latest
           args: '--release'
+          target: ''
         - id: macos-arm64
           os: macOS-latest
-          args: '--release --target=aarch64-apple-darwin'
+          target: 'aarch64-apple-darwin'
+          args: '--target=aarch64-apple-darwin'
         - id: windows
           os: windows-latest
           args: '--release'
+          target: ''
         - id: linux
           os: ubuntu-latest
           args: '--release'
+          target: ''
 
     env:
       GH_ACTIONS: true
@@ -39,6 +43,7 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
+          target: ${{ matrix.build.target }}
 
       - name: Log versions
         run: |
@@ -68,11 +73,8 @@ jobs:
           sudo apt-get install libwebkit2gtk-4.0-dev
 
       - name: arm targets
-        if: matrix.build.os == 'macOS-latest'
-        run: |
-          rustup target add aarch64-apple-darwin
-          export SDKROOT=$(xcrun -sdk macosx11.1 --show-sdk-path)
-          export MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx11.1 --show-sdk-platform-version)
+        if: matrix.build.id == 'macos-arm64'
+        run: rustup target add aarch64-apple-darwin
 
       - name: Run cargo build
         uses: actions-rs/cargo@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,15 +21,9 @@ jobs:
         - id: windows
           os: windows-latest
           target: 'x86_64-pc-windows-msvc'
-        - id: windows-arm
-          os: windows-latest
-          target: 'aarch64-pc-windows-msvc'
         - id: linux
           os: ubuntu-latest
           target: 'x86_64-unknown-linux-gnu'
-        - id: linux-arm
-          os: ubuntu-latest
-          target: 'aarch64-unknown-linux-gnu'
 
     env:
       GH_ACTIONS: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,8 +109,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: "webview_deno release"
-          draft: true
           files: |
             libwebview_deno.x86_64.dylib
             libwebview_deno.aarch64.dylib

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,7 @@ jobs:
 
       - uses: actions/upload-artifact@v3
         with:
+          name: ${{ matrix.build }}
           path: |
             target/release/libwebview_deno.dylib
             target/release/libwebview_deno.so

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,20 +14,22 @@ jobs:
         build:
         - id: macos
           os: macOS-latest
-          args: '--release'
-          target: ''
+          target: 'x86_64-apple-darwin'
         - id: macos-arm64
           os: macOS-latest
           target: 'aarch64-apple-darwin'
-          args: '--release --target=aarch64-apple-darwin'
         - id: windows
           os: windows-latest
-          args: '--release'
-          target: ''
+          target: 'x86_64-pc-windows-msvc'
+        - id: windows-arm
+          os: windows-latest
+          target: 'aarch64-pc-windows-msvc'
         - id: linux
           os: ubuntu-latest
-          args: '--release'
-          target: ''
+          target: 'x86_64-unknown-linux-gnu'
+        - id: linux-arm
+          os: ubuntu-latest
+          target: 'aarch64-unknown-linux-gnu'
 
     env:
       GH_ACTIONS: true
@@ -73,10 +75,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install libwebkit2gtk-4.0-dev
 
-      - name: arm targets
-        if: matrix.build.id == 'macos-arm64'
-        run: rustup target add aarch64-apple-darwin
-
       - name: Run cargo build
         uses: actions-rs/cargo@v1
         with:
@@ -87,11 +85,11 @@ jobs:
         with:
           name: ${{ matrix.build.id }}
           path: |
-            target/release/libwebview_deno.dylib
-            target/aarch64-apple-darwin/release/libwebview_deno.dylib
-            target/release/libwebview_deno.so
-            target/release/webview_deno.dll
-            target/release/Webview2Loader.dll
+            target/**/libwebview_deno.dylib
+            target/**/libwebview_deno.dylib
+            target/**/libwebview_deno.so
+            target/**/webview_deno.dll
+            target/**/Webview2Loader.dll
 
       - name: Release Plugin
         uses: softprops/action-gh-release@master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,12 @@ name: CI release
 
 on:
   push:
-
+    branches:
+      - main
+    paths:
+      - "Cargo.toml"
+      - "src/**"
+      - ".github/workflows/**"
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         - id: macos-arm64
           os: macOS-latest
           target: 'aarch64-apple-darwin'
-          args: '--target=aarch64-apple-darwin'
+          args: '--release --target=aarch64-apple-darwin'
         - id: windows
           os: windows-latest
           args: '--release'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,17 +79,17 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: ${{ matrix.build.args }}
+          args: --release --target=${{ matrix.build.target }}
 
       - uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.build.id }}
           path: |
-            target/**/libwebview_deno.dylib
-            target/**/libwebview_deno.dylib
-            target/**/libwebview_deno.so
-            target/**/webview_deno.dll
-            target/**/Webview2Loader.dll
+            target/${{ matrix.build.target }}/release/libwebview_deno.dylib
+            target/${{ matrix.build.target }}/release/libwebview_deno.dylib
+            target/${{ matrix.build.target }}/release/libwebview_deno.so
+            target/${{ matrix.build.target }}/release/webview_deno.dll
+            target/${{ matrix.build.target }}/release/Webview2Loader.dll
 
       - name: Release Plugin
         uses: softprops/action-gh-release@master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,17 +55,17 @@ jobs:
         uses: actions/cache@v1
         with:
           path: ~/.cargo/registry
-          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ matrix.build.id }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
       - name: Cache cargo index
         uses: actions/cache@v1
         with:
           path: ~/.cargo/git
-          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ matrix.build.id }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
       - name: Cache cargo build
         uses: actions/cache@v1
         with:
           path: target
-          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ matrix.build.id }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Install webkit2gtk
         if: matrix.build.os == 'ubuntu-latest'
@@ -88,7 +88,7 @@ jobs:
           name: ${{ matrix.build.id }}
           path: |
             target/release/libwebview_deno.dylib
-            target/aarch64-apple-darwin/libwebview_deno.dylib
+            target/aarch64-apple-darwin/release/libwebview_deno.dylib
             target/release/libwebview_deno.so
             target/release/webview_deno.dll
             target/release/Webview2Loader.dll

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,7 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
+          default: true
           target: ${{ matrix.build.target }}
 
       - name: Log versions

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,21 +77,21 @@ jobs:
 
       - name: Package macOS
         if:  matrix.build.id == 'macos'
-        run: mv ${{ github.workspace }}/target/${{ matrix.build.target }}/release/libwebview_deno.dylib libwebview_deno.x86_64.dylib
+        run: mv target/${{ matrix.build.target }}/release/libwebview_deno.dylib libwebview_deno.x86_64.dylib
 
       - name: Package macOS-arm
         if:  matrix.build.id == 'macos-arm64'
-        run: mv ${{ github.workspace }}/target/${{ matrix.build.target }}/release/libwebview_deno.dylib libwebview_deno.aarch64.dylib
+        run: mv target/${{ matrix.build.target }}/release/libwebview_deno.dylib libwebview_deno.aarch64.dylib
 
       - name: Package Windows
         if:  matrix.build.id == 'windows'
         run: |
-          mv ${{ github.workspace }}/target/${{ matrix.build.target }}/release/webview_deno.dll webview_deno.x86_64.dll
-          mv ${{ github.workspace }}/target/${{ matrix.build.target }}/release/Webview2Loader.dll Webview2Loader.dll
+          mv target/${{ matrix.build.target }}/release/webview_deno.dll webview_deno.x86_64.dll
+          mv target/${{ matrix.build.target }}/release/Webview2Loader.dll Webview2Loader.dll
 
       - name: Package Linux
         if:  matrix.build.id == 'linux'
-        run: mv ${{ github.workspace }}/target/${{ matrix.build.target }}/release/webview_deno.so webview_deno.x86_64.so
+        run: mv target/${{ matrix.build.target }}/release/libwebview_deno.so libwebview_deno.x86_64.so
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,12 +6,18 @@ on:
 
 jobs:
   build:
-    name: ${{ matrix.kind }} ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
+    name: ${{ matrix.kind }} ${{ matrix.build.os }}
+    runs-on: ${{ matrix.build.os }}
     timeout-minutes: 60
     strategy:
       matrix:
-        os: [macOS-latest, windows-latest, ubuntu-latest]
+        build:
+        - id: macos
+          os: macOS-latest
+        - id: windows
+          os: windows-latest
+        - id: linux
+          os: ubuntu-latest
 
     env:
       GH_ACTIONS: true
@@ -50,7 +56,7 @@ jobs:
           key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Install webkit2gtk
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.build.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
           sudo apt-get install libwebkit2gtk-4.0-dev
@@ -61,8 +67,17 @@ jobs:
           command: build
           args: --release
 
+      - uses: actions/upload-artifact@v3
+        with:
+          path: |
+            target/release/libwebview_deno.dylib
+            target/release/libwebview_deno.so
+            target/release/webview_deno.dll
+            target/release/Webview2Loader.dll
+
       - name: Release Plugin
         uses: softprops/action-gh-release@master
+        if: startsWith(github.ref, 'refs/tags/')
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
 
       - uses: actions/upload-artifact@v3
         with:
-          name: ${{ matrix.build }}
+          name: ${{ matrix.build.id }}
           path: |
             target/release/libwebview_deno.dylib
             target/release/libwebview_deno.so

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,12 +2,7 @@ name: CI release
 
 on:
   push:
-    branches:
-      - main
-    paths:
-      - "Cargo.toml"
-      - "src/**"
-      - ".github/workflows/**"
+
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    name: ${{ matrix.kind }} ${{ matrix.build.os }}
+    name: ${{ matrix.build.id }}
     runs-on: ${{ matrix.build.os }}
     timeout-minutes: 60
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,21 +77,21 @@ jobs:
 
       - name: Package macOS
         if:  matrix.build.id == 'macos'
-        run: mv target/${{ matrix.build.target }}/release/libwebview_deno.dylib libwebview_deno.x86_64.dylib
+        run: mv ${{ github.workspace }}/target/${{ matrix.build.target }}/release/libwebview_deno.dylib libwebview_deno.x86_64.dylib
 
       - name: Package macOS-arm
         if:  matrix.build.id == 'macos-arm64'
-        run: mv target/${{ matrix.build.target }}/release/libwebview_deno.dylib libwebview_deno.aarch64.dylib
+        run: mv ${{ github.workspace }}/target/${{ matrix.build.target }}/release/libwebview_deno.dylib libwebview_deno.aarch64.dylib
 
       - name: Package Windows
         if:  matrix.build.id == 'windows'
         run: |
-          mv target/${{ matrix.build.target }}/release/webview_deno.dll webview_deno.x86_64.dll
-          mv target/${{ matrix.build.target }}/release/Webview2Loader.dll Webview2Loader.dll
+          mv ${{ github.workspace }}/target/${{ matrix.build.target }}/release/webview_deno.dll webview_deno.x86_64.dll
+          mv ${{ github.workspace }}/target/${{ matrix.build.target }}/release/Webview2Loader.dll Webview2Loader.dll
 
       - name: Package Linux
         if:  matrix.build.id == 'linux'
-        run: mv target/${{ matrix.build.target }}/release/webview_deno.so webview_deno.x86_64.so
+        run: mv ${{ github.workspace }}/target/${{ matrix.build.target }}/release/webview_deno.so webview_deno.x86_64.so
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,16 @@ jobs:
         build:
         - id: macos
           os: macOS-latest
+          args: '--release'
+        - id: macos-arm64
+          os: macOS-latest
+          args: '--release --target=aarch64-apple-darwin'
         - id: windows
           os: windows-latest
+          args: '--release'
         - id: linux
           os: ubuntu-latest
+          args: '--release'
 
     env:
       GH_ACTIONS: true
@@ -61,17 +67,25 @@ jobs:
           sudo apt-get update
           sudo apt-get install libwebkit2gtk-4.0-dev
 
+      - name: arm targets
+        if: matrix.build.os == 'macOS-latest'
+        run: |
+          rustup target add aarch64-apple-darwin
+          export SDKROOT=$(xcrun -sdk macosx11.1 --show-sdk-path)
+          export MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx11.1 --show-sdk-platform-version)
+
       - name: Run cargo build
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --release
+          args: ${{ matrix.build.args }}
 
       - uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.build.id }}
           path: |
             target/release/libwebview_deno.dylib
+            target/aarch64-apple-darwin/libwebview_deno.dylib
             target/release/libwebview_deno.so
             target/release/webview_deno.dll
             target/release/Webview2Loader.dll

--- a/src/ffi.ts
+++ b/src/ffi.ts
@@ -1,12 +1,12 @@
 import { CachePolicy, download, prepare } from "../deps.ts";
 
-const version = "0.7.0-dev.0";
+const version = "0.7.0-pre.0";
 const policy = Deno.env.get("PLUGIN_URL") === undefined
   ? CachePolicy.STORE
   : CachePolicy.NONE;
 
 const url = Deno.env.get("PLUGIN_URL") ??
-  `https://github.com/Snider/webview_deno/releases/download/${version}/`;
+  `https://github.com/webview/webview_deno/releases/download/${version}/`;
 
 const urls = {
   darwin: `${url}libwebview_deno.${Deno.build.arch}.dylib`,

--- a/src/ffi.ts
+++ b/src/ffi.ts
@@ -1,17 +1,17 @@
 import { CachePolicy, download, prepare } from "../deps.ts";
 
-const version = "0.7.0-pre.0";
+const version = "0.7.0-dev.0";
 const policy = Deno.env.get("PLUGIN_URL") === undefined
   ? CachePolicy.STORE
   : CachePolicy.NONE;
 
 const url = Deno.env.get("PLUGIN_URL") ??
-  `https://github.com/webview/webview_deno/releases/download/${version}/`;
+  `https://github.com/Snider/webview_deno/releases/download/${version}/`;
 
 const urls = {
-  darwin: `${url}/libwebview_deno.${Deno.build.arch}.dylib`,
-  windows: `${url}/webview_deno.${Deno.build.arch}.dll`,
-  linux: `${url}/libwebview_deno.${Deno.build.arch}.so`,
+  darwin: `${url}libwebview_deno.${Deno.build.arch}.dylib`,
+  windows: `${url}webview_deno.${Deno.build.arch}.dll`,
+  linux: `${url}libwebview_deno.${Deno.build.arch}.so`,
 };
 /**
  * Checks for the existence of `./WebView2Loader.dll` for running on Windows

--- a/src/ffi.ts
+++ b/src/ffi.ts
@@ -4,9 +4,15 @@ const version = "0.7.0-pre.0";
 const policy = Deno.env.get("PLUGIN_URL") === undefined
   ? CachePolicy.STORE
   : CachePolicy.NONE;
+
 const url = Deno.env.get("PLUGIN_URL") ??
   `https://github.com/webview/webview_deno/releases/download/${version}/`;
 
+const urls = {
+  darwin: `${url}/libwebview_deno.${Deno.build.arch}.dylib`,
+  windows: `${url}/webview_deno.${Deno.build.arch}.dll`,
+  linux: `${url}/libwebview_deno.${Deno.build.arch}.so`,
+};
 /**
  * Checks for the existence of `./WebView2Loader.dll` for running on Windows
  *
@@ -26,7 +32,7 @@ let preloaded = false;
  * Removes old version if it already existed, and only runs once.
  * Should be run on the main thread so that the `unload` gets hooked in properly, otherwise
  * make sure `unload` gets called during the `window.onunload` event (after all windows are closed).
- * 
+ *
  * Does not need to be run on non-windows platforms, but that is subject to change.
  */
 export async function preload() {
@@ -71,7 +77,7 @@ if (Deno.build.os === "windows") {
 
 const lib = await prepare({
   name: "webview_deno",
-  url,
+  urls,
   policy,
 }, {
   "deno_webview_create": {


### PR DESCRIPTION
This PR fixes: https://github.com/webview/webview_deno/issues/64

- adds Apple m1 support
- updates release job (fires only on a tag, can release from GitHub UI): https://github.com/Snider/webview_deno/releases/tag/0.7.0-dev.0
- adds per run workflow artefacts: https://github.com/Snider/webview_deno/actions/runs/2560779626


```
deno run -A --unstable https://raw.githubusercontent.com/Snider/webview_deno/pr-example/examples/local.ts
```
<img width="1205" alt="image" src="https://user-images.githubusercontent.com/631881/175775704-3f513e51-1b2b-42aa-b7af-e0e0721e9f98.png">

