### PR TITLE
fix: add support for deno 1.25.0

### DIFF
--- a/src/ffi.ts
+++ b/src/ffi.ts
@@ -131,7 +131,7 @@ export const lib = await prepare(
       result: "pointer",
     },
     "webview_set_title": {
-      parameters: ["pointer", "pointer"],
+      parameters: ["pointer", "buffer"],
       result: "void",
     },
     "webview_set_size": {
@@ -139,7 +139,7 @@ export const lib = await prepare(
       result: "void",
     },
     "webview_navigate": {
-      parameters: ["pointer", "pointer"],
+      parameters: ["pointer", "buffer"],
       result: "void",
     },
     "webview_set_html": {
@@ -147,23 +147,23 @@ export const lib = await prepare(
       result: "void",
     },
     "webview_init": {
-      parameters: ["pointer", "pointer"],
+      parameters: ["pointer", "buffer"],
       result: "void",
     },
     "webview_eval": {
-      parameters: ["pointer", "pointer"],
+      parameters: ["pointer", "buffer"],
       result: "void",
     },
     "webview_bind": {
-      parameters: ["pointer", "pointer", "function", "pointer"],
+      parameters: ["pointer", "buffer", "function", "pointer"],
       result: "void",
     },
     "webview_unbind": {
-      parameters: ["pointer", "pointer"],
+      parameters: ["pointer", "buffer"],
       result: "void",
     },
     "webview_return": {
-      parameters: ["pointer", "pointer", "i32", "pointer"],
+      parameters: ["pointer", "buffer", "i32", "buffer"],
       result: "void",
     },
   } as const,

--- a/src/webview.ts
+++ b/src/webview.ts
@@ -60,7 +60,7 @@ export interface Size {
  * ```
  */
 export class Webview {
-  #handle: bigint | null = null;
+  #handle: Deno.PointerValue | null = null;
   #callbacks: Map<
     string,
     Deno.UnsafeCallback<{
@@ -142,7 +142,7 @@ export class Webview {
    *
    * @param handle A previously created webview instances handle
    */
-  constructor(handle: bigint);
+  constructor(handle: Deno.PointerValue);
   /**
    * Creates a new webview instance.
    *
@@ -178,19 +178,20 @@ export class Webview {
   constructor(
     debug?: boolean,
     size?: Size,
-    window?: bigint | null,
+    window?: Deno.PointerValue | null,
   );
   constructor(
-    debugOrHandle: boolean | bigint = false,
+    debugOrHandle: boolean | Deno.PointerValue = false,
     size: Size | undefined = { width: 1024, height: 768, hint: SizeHint.NONE },
-    window: bigint | null = null,
+    window: Deno.PointerValue | null = null,
   ) {
-    this.#handle = typeof debugOrHandle === "bigint"
-      ? debugOrHandle
-      : lib.symbols.webview_create(
-        Number(debugOrHandle),
-        window,
-      );
+    this.#handle =
+      typeof debugOrHandle === "bigint" || typeof debugOrHandle === "number"
+        ? debugOrHandle
+        : lib.symbols.webview_create(
+          Number(debugOrHandle),
+          window,
+        );
 
     if (size !== undefined) {
       this.size = size;
@@ -251,9 +252,9 @@ export class Webview {
     callback: (
       seq: string,
       req: string,
-      arg: bigint | null,
+      arg: Deno.PointerValue | null,
     ) => void,
-    arg: bigint | null = null,
+    arg: Deno.PointerValue | null = null,
   ) {
     const callbackResource = new Deno.UnsafeCallback(
       {
@@ -261,12 +262,12 @@ export class Webview {
         result: "void",
       },
       (
-        seqPtr: bigint,
-        reqPtr: bigint,
-        arg: bigint | null,
+        seqPtr: Deno.PointerValue,
+        reqPtr: Deno.PointerValue,
+        arg: Deno.PointerValue | null,
       ) => {
-        const seq = new Deno.UnsafePointerView(seqPtr).getCString();
-        const req = new Deno.UnsafePointerView(reqPtr).getCString();
+        const seq = new Deno.UnsafePointerView(BigInt(seqPtr)).getCString();
+        const req = new Deno.UnsafePointerView(BigInt(reqPtr)).getCString();
         callback(seq, req, arg);
       },
     );


### PR DESCRIPTION
Hey folks,

with reference to #134 this introduces the specialized `buffer` type for `CStrings` to make webview_deno work with the [newest breakting change of deno ffi](https://github.com/denoland/deno/pull/15518).

It will most likely break webview_deno for older versions of deno (< 1.25.0) as the ffi api change is breaking!

Kind regards
@lukas-runge