### PR TITLE
print command before running

### DIFF
--- a/script/build.ts
+++ b/script/build.ts
@@ -39,6 +39,8 @@ async function spawn<T extends Deno.SpawnOptions>(
   exit ??= ExitType.Never;
   log ??= LogType.Always;
 
+  console.log(`Running "${cmd} ${(opts?.args ?? []).join(" ")}"`);
+
   const result = await Deno.spawn(cmd, opts);
 
   const stdout = decoder.decode(result.stdout!);


### PR DESCRIPTION
be more verbose on errors

```diff
 deno task build
 Warning deno task is unstable and may drastically change in the future
 Task build deno run -A --unstable script/build.ts
+Running "pkg-config --cflags --libs gtk+-3.0 webkit2gtk-4.0"
 error: Uncaught (in promise) NotFound: No such file or directory (os error 2)
   const result = await Deno.spawn(cmd, opts);
                             ^
     at spawnChild (deno:runtime/js/40_spawn.js:36:23)
     at Object.spawn (deno:runtime/js/40_spawn.js:231:12)
     at spawn (file:///tmp/tmp.aGowOqCn9e/vscode/vscode-deno/webview_deno/script/build.ts:43:29)
     at file:///tmp/tmp.aGowOqCn9e/vscode/vscode-deno/webview_deno/script/build.ts:131:30
```

the `No such file` error is not helpful
