### PR TITLE
feat: allow multiple instances at the same root

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -1,1 +1,1 @@
-export { dlopen, download } from "https://deno.land/x/plug@1.0.0-rc.3/mod.ts";
+export { dlopen } from "https://deno.land/x/plug@1.0.0-rc.3/mod.ts";

--- a/mod.ts
+++ b/mod.ts
@@ -1,2 +1,2 @@
 export * from "./src/webview.ts";
-export { preload, unload } from "./src/ffi.ts";
+export { unload } from "./src/ffi.ts";

--- a/src/ffi.ts
+++ b/src/ffi.ts
@@ -23,8 +23,8 @@ export function encodeCString(value: string) {
  *
  * @returns true if it exists, false if it doesn't
  */
-async function checkForWebView2Loader(): Promise<boolean> {
-  return await Deno.stat("./WebView2Loader.dll").then(
+function checkForWebView2Loader(): Promise<boolean> {
+  return Deno.stat("./WebView2Loader.dll").then(
     () => true,
     (e) => e instanceof Deno.errors.NotFound ? false : true,
   );

--- a/src/ffi.ts
+++ b/src/ffi.ts
@@ -74,7 +74,11 @@ export function unload() {
   }
   lib.close();
   if (Deno.build.os === "windows") {
-    Deno.removeSync("./WebView2Loader.dll");
+    //Try to remove "./WebView2Loader.dll" if it exists
+    Deno.remove("./WebView2Loader.dll").catch((e) => {
+      if (e instanceof Deno.errors.NotFound) return;
+      throw e;
+    });
   }
 }
 

--- a/src/ffi.ts
+++ b/src/ffi.ts
@@ -139,3 +139,9 @@ export const lib = await dlopen(
     },
   } as const,
 );
+
+// Prevent memory leaks on uncaught promises errors
+addEventListener('unhandledrejection', (e) => {
+  unload();
+  throw e;
+})

--- a/src/ffi.ts
+++ b/src/ffi.ts
@@ -1,7 +1,7 @@
 import { dlopen } from "../deps.ts";
 import { Webview } from "./webview.ts";
 
-const version = "0.7.3";
+const version = "0.7.4";
 const cache = Deno.env.get("PLUGIN_URL") === undefined ? "use" : "reloadAll";
 const url = Deno.env.get("PLUGIN_URL") ??
   `https://github.com/webview/webview_deno/releases/download/${version}/`;

--- a/src/ffi.ts
+++ b/src/ffi.ts
@@ -33,7 +33,7 @@ export const instances: Webview[] = [];
  *
  * Does not need to be run on non-windows platforms, but that is subject to change.
  */
-if (Deno.build.os === 'windows') {
+if (Deno.build.os === "windows") {
   //Download and cache `./WebView2Loader.dll`
   const { default: dll } = await import(`https://ejm.sh/${url}/WebView2Loader.dll?.json`, { assert: { type: 'json' } }) as { default: { b64: string } };
   const dataUrl = `data:application/octet-stream;base64,${dll.b64}`;
@@ -41,20 +41,20 @@ if (Deno.build.os === 'windows') {
 
   //Overwrite local dll with the version specified in "url"
   try {
-    const fsFile = await Deno.open('./WebView2Loader.dll', { create: true, write: true })
+    const fsFile = await Deno.open("./WebView2Loader.dll", { create: true, write: true });
     await webview2loader?.pipeTo(fsFile.writable); //fsFile is closed by the stream
   } catch (e) {
     const entries = await (async () => {
-      const array: Deno.DirEntry[] = []
-      for await (const entry of Deno.readDir('.')) array.push(entry)
-      return array
-    })()
+      const array: Deno.DirEntry[] = [];
+      for await (const entry of Deno.readDir(".")) array.push(entry);
+      return array;
+    })();
     //Check if error is only caused by process lock
-    if (!entries.some(entry => entry.name === 'WebView2Loader.dll')) throw e
+    if (!entries.some(entry => entry.name === "WebView2Loader.dll")) throw e;
     /**
      * WebView2Loader.dll is already used
      * Do not crash to allow multiple execution at the same root
-     * WebView2Loader.dll is correctly reùoved in unload()
+     * WebView2Loader.dll is correctly resolved in unload()
      */
   }
 

--- a/src/ffi.ts
+++ b/src/ffi.ts
@@ -41,8 +41,7 @@ if (Deno.build.os === 'windows') {
 
   //Overwrite local dll with the version specified in "url"
   const fsFile = await Deno.open('./WebView2Loader.dll', { create: true, write: true });
-  await webview2loader?.pipeTo(fsFile.writable);
-  fsFile.close();
+  await webview2loader?.pipeTo(fsFile.writable); //fsFile is closed by the stream
 
   self.addEventListener("unload", unload);
 }

--- a/src/ffi.ts
+++ b/src/ffi.ts
@@ -1,4 +1,4 @@
-import { dlopen, download } from "../deps.ts";
+import { dlopen } from "../deps.ts";
 import { Webview } from "./webview.ts";
 
 const version = "0.7.3";
@@ -64,17 +64,6 @@ export function unload() {
       if (e instanceof Deno.errors.NotFound) return;
       throw e;
     });
-  }
-}
-
-// Automatically run the preload if we're on windows and on the main thread.
-if (Deno.build.os === "windows") {
-  if ((self as never)["window"]) {
-    await preload();
-  } else if (!await checkForWebView2Loader()) {
-    throw new Error(
-      "WebView2Loader.dll does not exist! Make sure to run preload() from the main thread.",
-    );
   }
 }
 

--- a/src/ffi.ts
+++ b/src/ffi.ts
@@ -19,21 +19,6 @@ export function encodeCString(value: string) {
 }
 
 /**
- * Checks for the existence of `./WebView2Loader.dll` for running on Windows.
- *
- * @returns true if it exists, false if it doesn't
- */
-function checkForWebView2Loader(): Promise<boolean> {
-  return Deno.stat("./WebView2Loader.dll").then(
-    () => true,
-    (e) => e instanceof Deno.errors.NotFound ? false : true,
-  );
-}
-
-// make sure we don't preload twice
-let preloaded = false;
-
-/**
  * All active webview instances. This is internally used for automatically
  * destroying all instances once {@link unload} is called.
  */


### PR DESCRIPTION
# Motivation
Due to file lock of Webview2Loader, only 1 instance of webview can run for a given execution path

# Changes
- Rewrite the preload function in ffi.ts
- Change caching method of Webview2Loader.dll in favor of internal cache by deno via [ejm.sh](https://ejm.sh) 
- Refactor some parts
- Update release url in ffi.ts