### PR TITLE
fix: bind function stopped working on Deno 1.31+

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -1,1 +1,1 @@
-export { dlopen, download } from "https://deno.land/x/plug@1.0.0-rc.3/mod.ts";
+export { dlopen, download } from "https://deno.land/x/plug@1.0.1/mod.ts";

--- a/deps.ts
+++ b/deps.ts
@@ -1,1 +1,1 @@
-export { dlopen, download } from "https://deno.land/x/plug@1.0.1/mod.ts";
+export { dlopen, download } from "https://deno.land/x/plug@1.0.2/mod.ts";

--- a/src/webview.ts
+++ b/src/webview.ts
@@ -267,8 +267,12 @@ export class Webview {
         reqPtr: Deno.PointerValue,
         arg: Deno.PointerValue | null,
       ) => {
-        const seq = seqPtr ? new Deno.UnsafePointerView(seqPtr).getCString() : '-1';
-        const req = reqPtr ? new Deno.UnsafePointerView(reqPtr).getCString() : '[]';
+        const seq = seqPtr
+          ? new Deno.UnsafePointerView(seqPtr).getCString()
+          : "-1";
+        const req = reqPtr
+          ? new Deno.UnsafePointerView(reqPtr).getCString()
+          : "[]";
         callback(seq, req, arg);
       },
     );

--- a/src/webview.ts
+++ b/src/webview.ts
@@ -269,10 +269,10 @@ export class Webview {
       ) => {
         const seq = seqPtr
           ? new Deno.UnsafePointerView(seqPtr).getCString()
-          : "-1";
+          : "";
         const req = reqPtr
           ? new Deno.UnsafePointerView(reqPtr).getCString()
-          : "[]";
+          : "";
         callback(seq, req, arg);
       },
     );

--- a/src/webview.ts
+++ b/src/webview.ts
@@ -1,3 +1,4 @@
+/// <reference lib="deno.unstable" />
 import { encodeCString, instances, lib } from "./ffi.ts";
 
 /** Window size hints */
@@ -266,8 +267,8 @@ export class Webview {
         reqPtr: Deno.PointerValue,
         arg: Deno.PointerValue | null,
       ) => {
-        const seq = new Deno.UnsafePointerView(BigInt(seqPtr)).getCString();
-        const req = new Deno.UnsafePointerView(BigInt(reqPtr)).getCString();
+        const seq = seqPtr ? new Deno.UnsafePointerView(seqPtr).getCString() : '-1';
+        const req = reqPtr ? new Deno.UnsafePointerView(reqPtr).getCString() : '[]';
         callback(seq, req, arg);
       },
     );


### PR DESCRIPTION
- Upgraded `plug` module
- Modified `bindRaw` to accept the raw PointerValue, [which is now an object](https://github.com/denoland/deno/pull/16889)