### PR TITLE
feat: add `html` setter binding `set_html`

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ const html = `
 
 const webview = new Webview();
 
-webview.navigate(`data:text/html,${encodeURIComponent(html)}`);
+webview.html = html;
+
 webview.run();
 ```
 

--- a/examples/bind.ts
+++ b/examples/bind.ts
@@ -13,7 +13,7 @@ const html = `
 
 const webview = new Webview();
 
-webview.navigate(`data:text/html,${encodeURIComponent(html)}`);
+webview.html = html;
 
 let counter = 0;
 webview.bind("press", (a, b, c) => {

--- a/examples/local.ts
+++ b/examples/local.ts
@@ -10,5 +10,6 @@ const html = `
 
 const webview = new Webview();
 
-webview.navigate(`data:text/html,${encodeURIComponent(html)}`);
+webview.html = html;
+
 webview.run();

--- a/examples/user_agent.ts
+++ b/examples/user_agent.ts
@@ -10,5 +10,6 @@ const html = `
 
 const webview = new Webview();
 
-webview.navigate(`data:text/html,${encodeURIComponent(html)}`);
+webview.html = html;
+
 webview.run();

--- a/src/ffi.ts
+++ b/src/ffi.ts
@@ -142,7 +142,7 @@ export const lib = await dlopen(
       result: "void",
     },
     "webview_set_html": {
-      parameters: ["pointer", "pointer"],
+      parameters: ["pointer", "buffer"],
       result: "void",
     },
     "webview_init": {

--- a/src/webview.ts
+++ b/src/webview.ts
@@ -137,6 +137,32 @@ export class Webview {
     lib.symbols.webview_set_title(this.#handle, encodeCString(title));
   }
 
+  /**
+   * Sets the html contents of the window
+   *
+   * ## Example
+   *
+   * ```ts
+   * import { Webview } from "../mod.ts";
+   *
+   * const webview = new Webview();
+   *
+   * // Set the window html content to "<html><body>Hello World</body></html>"
+   * webview.html = `
+   *   <html>
+   *   <body>
+   *     <h1>Hello from deno v${Deno.version.deno}</h1>
+   *   </body>
+   *   </html>
+   * `;
+   *
+   * webview.run();
+   * ```
+   */
+  set html(html: string) {
+    lib.symbols.webview_set_html(this.#handle, encodeCString(html));
+  }
+
   /** **UNSAFE**: Highly unsafe API, beware!
    *
    * Creates a new webview instance from a webview handle.

--- a/src/webview.ts
+++ b/src/webview.ts
@@ -45,8 +45,9 @@ export interface Size {
  * `;
  *
  * const webview = new Webview();
+ * 
+ * webview.html = html;
  *
- * webview.navigate(`data:text/html,${encodeURIComponent(html)}`);
  * webview.run();
  * ```
  *
@@ -340,7 +341,7 @@ export class Webview {
    *
    * const webview = new Webview();
    *
-   * webview.navigate(`data:text/html,${encodeURIComponent(html)}`);
+   * webview.html = html;
    *
    * let counter = 0;
    * // Create and bind `press` to the webview javascript instance.


### PR DESCRIPTION
# Changes
1. `ffi.ts`: fixed the second parameter of "webview_set_html" symbol to "buffer" from "pointer".
2. `webview.ts`: added `html` setter that basically wraps `webview_set_html` symbol.
3. Replaced all the examples using `navigate` method to set Webview HTML.