### PR TITLE
fix: main thread check in deno 2

### DIFF
--- a/src/ffi.ts
+++ b/src/ffi.ts
@@ -88,7 +88,7 @@ export function unload() {
 
 // Automatically run the preload if we're on windows and on the main thread.
 if (Deno.build.os === "windows") {
-  if ((self as never)["window"]) {
+  if (self === globalThis) {
     await preload();
   } else if (!await checkForWebView2Loader()) {
     throw new Error(


### PR DESCRIPTION
need a robust way to check if it is running under the main thread or not, as self.window is not exist any more!

ref:
https://github.com/denoland/deno/pull/22057
 