### PR TITLE
docs: update install to use jsr prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Webview is published to [jsr.io](https://jsr.io/@webview/webview) and
 use JSR:
 
 ```bash
-deno add @webview/webview
+deno add jsr:@webview/webview
 ```
 
 or without the CLI:


### PR DESCRIPTION
I guess this changed at some point, but the latest deno versions require the prefix